### PR TITLE
Add a filter for the WC Shortcode wrapper.

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -65,6 +65,7 @@ class WC_Shortcodes {
 			'after'  => null,
 		)
 	) {
+		$wrapper = apply_filters( 'woocommerce_shortcode_wrapper', $wrapper );
 		ob_start();
 
 		// @codingStandardsIgnoreStart


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It would be helpful to have some control over the `WC_Shortcode` wrapper. Presently, if we wish to change the wrapping HTML, it involves either placing such changes into the post content (bad!) or creating custom shortcodes with their own wrappers and invoking the WC shortcodes within. The latter is not ideal because it breaks the WC conditionals which detect specific shortcodes in the content.

I added a simple filter for the (presently hard-coded) `$wrapper` variable. I considered adding the `$function` as an additional parameter but don't feel so great about passing a `callable` to a filter. I welcome suggestions on any additional params to pass that can help the user of the filter determine the shortcode being called.### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Added a filter for the `$wrapper` variable used by WC_Shortcodes.
